### PR TITLE
Updated dashboard.js to fix a bug

### DIFF
--- a/visualizer/dashboard.js
+++ b/visualizer/dashboard.js
@@ -89,7 +89,7 @@ function queryIfDisplayed(id) {
 }
 
 function formatDollars(amount) {
-    return amount.toLocaleString("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 0 })
+    return amount.toLocaleString("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 2 })
 }
 
 setDataStatus(DATA_STATUS_ZERO)


### PR DESCRIPTION
The formatDollars function used maximumFractionDigits as 0, and the style used is "currency", with currency "USD". This causes an exception, and the value is never updated on screen.
According to specification, the maximum value should be between the minimum for the style and 20. For currency, the minimum is defined by ISO 4217 according to the currency type, which sets the minimum fraction of USD to 2.